### PR TITLE
TASK: Allow Flow 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "name": "dimaip/twitterhelper",
     "require": {
-        "neos/flow": "^4.0 | ^5.0 | ^6.0",
+        "neos/flow": "^4.0 | ^5.0 | ^6.0 | ^7.0",
         "j7mbo/twitter-api-php": "*"
     },
     "license": "LGPL-3.0+",


### PR DESCRIPTION
Just changed the required flow version in composer.json.

@dimaip What do you think about using
`"neos/flow": ">=4.0 | dev-master",`
instead? Maybe this reduces maintenance work for the next flow releases?